### PR TITLE
feat(spotify)

### DIFF
--- a/app/Http/Controllers/App/Spotify/SpotifyController.php
+++ b/app/Http/Controllers/App/Spotify/SpotifyController.php
@@ -16,23 +16,20 @@ class SpotifyController extends Controller
     {
         Log::info('Redirecting to Spotify');
 
-        $mode = $request->query('mode', \Auth::check() ? 'link' : 'login');
+        $mode = $request->query('mode', Auth::check() ? 'link' : 'login');
 
-        $response = Socialite::driver('spotify')
+        // Guarda tu modo en sesión (NO usar state para esto)
+        session(['spotify.mode' => $mode]);
+
+        return Socialite::driver('spotify')
             ->scopes(['user-read-email'])
-            ->redirectUrl(config('services.spotify.redirect')) // <- FORZADO
-            ->with(['state' => $mode])
+            ->redirectUrl(config('services.spotify.redirect'))
             ->redirect();
-
-        // Debug temporal (borra esto luego):
-        Log::info('spotify_auth_url', ['url' => $response->getTargetUrl()]);
-
-        return $response;
     }
 
     public function callback(Request $request, SpotifyService $service)
     {
-        $user = $service->handleCallback(); // devuelve el User resuelto
+        $user = $service->handleCallback();
         Auth::login($user, remember: true);
 
         return redirect()->route('Dashboard');


### PR DESCRIPTION
This pull request improves the Spotify OAuth flow by making the handling of the "mode" parameter (login vs. link) more secure and reliable, and refactors the logic for associating Spotify accounts with application users. The changes ensure that the user's intent (login or link) is preserved throughout the authentication process and that user and connected account records are managed more robustly.

**Spotify OAuth flow improvements:**

* The "mode" parameter (login or link) is now stored in the session during the redirect instead of being passed via the OAuth state parameter, making the flow more secure and less error-prone. (`SpotifyController.php`, `SpotifyService.php`) [[1]](diffhunk://#diff-a0c80482a57696e58d900251085c8d3d10cc10098f0e74af570c5cbf53969d8eL19-R32) [[2]](diffhunk://#diff-9c0abc75b512325380df3f796b66a87117dd472787fc366f87a9e84961e3c2b2R17-R72)
* During the OAuth callback, the mode is retrieved from the session, and the logic for resolving or creating the user and connected account is refactored for clarity and reliability. This includes always associating the connected account with a user and handling cases where the Spotify account is already linked. (`SpotifyService.php`)

**Code and logic cleanup:**

* Removed unnecessary debug code and simplified conditional logic in the controller's redirect and callback methods. (`SpotifyController.php`)
* Improved handling of user creation, including generating a secure random password and ensuring that a user is always associated with a connected Spotify account. (`SpotifyService.php`)…and enhancing user linking