### PR TITLE
fix: update routing for playlist navigation in Stats component

### DIFF
--- a/resources/js/Pages/Dashboard/Stats.jsx
+++ b/resources/js/Pages/Dashboard/Stats.jsx
@@ -416,7 +416,7 @@ export default function Stats({ statsData }) {
                                                                     key={pl.id}
                                                                     className="playlist-subitem"
                                                                     onClick={() =>
-                                                                        router.visit(route("playlist.show", pl.id))
+                                                                        router.visit(route("emotion.playlists.show", pl.id))
                                                                     }
                                                                 >
                                                                     <img


### PR DESCRIPTION
This pull request makes a small update to the `Stats` component in the dashboard. The route used when clicking on a playlist item has been changed to point to the correct emotion-based playlist show route.